### PR TITLE
Adding cmake dep for 16.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Plasma 5 applet for minimizing visible windows
 
 ### More Specifically for Ubuntu 16.04 Xenial
 ```
-sudo apt-get install extra-cmake-modules qtdeclarative5-dev libkf5windowsystem-dev
+sudo apt-get install cmake extra-cmake-modules qtdeclarative5-dev libkf5windowsystem-dev
 ```
 
 ## Compile and install


### PR DESCRIPTION
Hi,

This is a fairly minor edit, but `extra-cmake-modules` (nor any other packages listed in the sudo apt-get install command) does not automatically draw in the `cmake` package, so it is important to manually add `cmake` to this command.

Thanks for your time,
Brenton
